### PR TITLE
Properly list all installed packages, and ignore blacklisted ones

### DIFF
--- a/list.go
+++ b/list.go
@@ -26,6 +26,7 @@ import (
 	"go.arsenm.dev/lure/internal/db"
 	"go.arsenm.dev/lure/internal/repos"
 	"go.arsenm.dev/lure/manager"
+	"golang.org/x/exp/slices"
 )
 
 func listCmd(c *cli.Context) error {
@@ -67,11 +68,15 @@ func listCmd(c *cli.Context) error {
 			return err
 		}
 
+		if slices.Contains(cfg.IgnorePkgUpdates, pkg.Name) {
+			continue
+		}
+
 		version := pkg.Version
 		if c.Bool("installed") {
 			instVersion, ok := installed[pkg.Name]
 			if !ok {
-				return nil
+				continue
 			} else {
 				version = instVersion
 			}


### PR DESCRIPTION
This PR fixes the issue when if a package matching the query wasn't installed, the program exited. As a result, it closes #60.
Also, now list ignores packages blacklisted by the config.